### PR TITLE
pyproject: add missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 keywords = ["reproducible builds", "fedora"]
 requires-python = ">=3.9"
-dependencies = ["ipcqueue"]
+dependencies = ["ipcqueue", "requests"]
 
 [project.urls]
 Homepage = "https://github.com/keszybz/fedora-repro"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 keywords = ["reproducible builds", "fedora"]
 requires-python = ">=3.9"
-dependencies = ["ipcqueue", "requests"]
+dependencies = ["ipcqueue", "koji", "requests"]
 
 [project.urls]
 Homepage = "https://github.com/keszybz/fedora-repro"


### PR DESCRIPTION
Without `requests` and `koji` the `fedora-repro` package in rawhide throws an exception.